### PR TITLE
Added base Peewee model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ test.py
 otp/.DS_Store
 gtfs/.DS_Store
 *.pyc
+
+env
+.gitignore
+.vscode
+results.db
+*.zip

--- a/utils/db.py
+++ b/utils/db.py
@@ -1,0 +1,48 @@
+from peewee import Model, SqliteDatabase, TextField, ForeignKeyField
+
+database = SqliteDatabase('results.db')
+
+
+class BaseModel(Model):
+    class Meta:
+        database = database
+        legacy_table_names = False
+
+
+class BlockGroup(BaseModel):
+    name = TextField()
+    description = TextField()
+
+
+class ScoreType(BaseModel):
+    name = TextField()
+    description = TextField()
+
+
+class Score(BaseModel):
+    block_group = ForeignKeyField(BlockGroup, backref='scores')
+    score_type = ForeignKeyField(ScoreType, backref='scores')
+
+
+class PopulationType(BaseModel):
+    name = TextField()
+    description = TextField()
+
+
+class Population(BaseModel):
+    block_group = ForeignKeyField(BlockGroup, backref='populations')
+    population_type = ForeignKeyField(PopulationType, backref='populations')
+
+
+class Tag(BaseModel):
+    name = TextField()
+
+
+class BlockGroupTag(BaseModel):
+    block_group = ForeignKeyField(BlockGroup, backref='block_group_tags')
+    tag = ForeignKeyField(Tag, backref='block_group_tags')
+
+
+if __name__ == "__main__":
+    database.connect()
+    database.create_tables([BlockGroup, ScoreType, Score, PopulationType, Population, Tag, BlockGroupTag])


### PR DESCRIPTION
Added the basic model definition for the results database, it can be found it utils/db.py

Use is pretty simple: `from utils.db import Score, etc`

Then standard create and update functions can be accessed. You must run the file directly first to create a temporary SQLite database.